### PR TITLE
Fix injected %FIELDS by T::MO::Extends

### DIFF
--- a/lib/Test/MockObject/Extends.pm
+++ b/lib/Test/MockObject/Extends.pm
@@ -4,8 +4,6 @@ use strict;
 use warnings;
 
 use Test::MockObject;
-use Hash::Util ();
-use fields ();
 
 sub import
 {


### PR DESCRIPTION
The first commit fixes a `once` warning on 5.10.1 (see test case by @maxatome below) that can occur when extending a class that is not fields-based.

The two other commits are optimisations in `Test::MockObject::Extends`:
- resolve `$^V gt v5.9.0` at compile time
- avoid loading fields.pm and Hash::Util

Cc: @maxatome
