### PR TITLE
Enable travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
-  - "5.8"
+  # Dist::Zilla::Role::GitConfig requires 5.10+ :(
+  #- "5.8"
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
 install:


### PR DESCRIPTION
This commit adds configuration for [Travis-CI](https://travis-ci.org/).
In addition to this configuration the build must be enabled at travis-ci.org by the repository owner.

Sample output: https://travis-ci.org/dolmen/p5-Test-MockObject
