### PR TITLE
Mark CGI, Test::More, Test::Exception as 'test/requires' dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,8 @@ format = {{ cldr('1.yyyyMMdd') }}
 [Prereqs]
 UNIVERSAL::isa  = 1.20110614
 UNIVERSAL::can  = 1.20110617
+
+[Prereqs / TestRequires]
 CGI             = 4.15
 Test::More      = 0.98
 Test::Exception = 0.31


### PR DESCRIPTION
Mark CGI, Test::More, Test::Exception as `test/requires` dependencies instead of `runtime/requires` dependencies as those modules are only used in tests.
Test::Builder (which is part of the same distribution as Test::More) is used at runtime, but that dependency is automatically injected by `[AutoPrereqs]`.

The list of dependencies can be verified with `dzil listdeps --json`.