### PR TITLE
No eval string

### DIFF
--- a/lib/Test/MockObject.pm
+++ b/lib/Test/MockObject.pm
@@ -9,8 +9,14 @@ sub import
 {
     my $self = shift;
     return unless grep /^-debug/, @_;
-    eval "use UNIVERSAL::isa 'verbose'";
-    eval "use UNIVERSAL::can '-always_warn'";
+    eval {
+	require UNIVERSAL::isa;
+	UNIVERSAL::isa::->import('verbose');
+    };
+    eval {
+	require UNIVERSAL::can;
+	UNIVERSAL::can::->import('-always_warn');
+    };
 }
 
 use Test::Builder;

--- a/lib/Test/MockObject/Extends.pm
+++ b/lib/Test/MockObject/Extends.pm
@@ -5,11 +5,9 @@ use warnings;
 
 use Test::MockObject;
 
-sub import
-{
-    my $self = shift;
-    Test::MockObject->import( @_ );
-}
+# Alias our 'import' to T:MO::import to handle this:
+#    use Test::MockObject::Extends '-debug';
+*import = \&Test::MockObject::import;
 
 use Devel::Peek  'CvGV';
 use Scalar::Util 'blessed';

--- a/lib/Test/MockObject/Extends.pm
+++ b/lib/Test/MockObject/Extends.pm
@@ -8,7 +8,6 @@ use Test::MockObject;
 sub import
 {
     my $self = shift;
-    eval "use Test::MockObject";
     Test::MockObject->import( @_ );
 }
 


### PR DESCRIPTION
3 changes applied to Test::MockObject::import and Test::MockObject::Extends::import to use `eval { ... }' instead of `eval "..."` (eval sting is much slower as it needs a full separate compiler context).