### PR TITLE
Remove CGI dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,7 +20,6 @@ UNIVERSAL::isa  = 1.20110614
 UNIVERSAL::can  = 1.20110617
 
 [Prereqs / TestRequires]
-CGI             = 4.15
 Test::More      = 0.98
 Test::Exception = 0.31
 Test::Warn      = 0.23

--- a/t/extends.t
+++ b/t/extends.t
@@ -16,8 +16,8 @@ $tme    = $module->new( 'Test::Builder' );
 ok( $tme->isa( 'Test::Builder' ),
 	'passing a class name to new() should set inheritance properly' );
 
-$tme      = $module->new( 'CGI' );
-ok( $INC{'CGI.pm'},
+$tme      = $module->new( 'CPAN' );
+ok( $INC{'CPAN.pm'},
 	'new() should load parent module unless already loaded' );
 
 package Some::Class;
@@ -213,5 +213,5 @@ is( $called_fooNA,          1, '... calling the method'          );
 is( $called_autoloadNA,     0, '... not touching AUTOLOAD()'     );
 
 # Call a non-existent method
-dies_ok (sub{ $mock->bar()},     
+dies_ok (sub{ $mock->bar()},
     '... should die if calling a non-mocked and non-AUTOLOADED method' );


### PR DESCRIPTION
CGI was only used in a test, so it doesn't really make
sense to drag it in. I replaced it with `CPAN`,
which has the advantage to be coming with Perl itself,
so there is no additional installation required.