### PR TITLE
Teach mock() to accept multiple mocks at once.

### DIFF
--- a/lib/Test/MockObject.pm
+++ b/lib/Test/MockObject.pm
@@ -33,12 +33,15 @@ sub new
 
 sub mock
 {
-    my ($self, $name, $sub) = @_;
-    $sub ||= sub {};
+    my ($self, @names_and_subs) = @_;
 
-    # leading dash means unlog, otherwise do log
-    _set_log( $self, $name, ( $name =~ s/^-// ? 0 : 1 ) );
-    _subs( $self )->{$name} = $sub;
+    while ( my ($name, $sub) = splice @names_and_subs, 0, 2 ) {
+        $sub ||= sub {};
+
+        # leading dash means unlog, otherwise do log
+        _set_log( $self, $name, ( $name =~ s/^-// ? 0 : 1 ) );
+        _subs( $self )->{$name} = $sub;
+    }
 
     $self;
 }
@@ -545,10 +548,10 @@ feature came about in version 0.09.  Shorter testing code is nice!
 
 =over 4
 
-=item * C<mock(I<name>, I<coderef>)>
+=item * C<mock(I<name>, I<coderef> [, I<name2>, I<coderef2>, ...])>
 
-Adds a coderef to the object.  This allows code to call the named method on the
-object.  For example, this code:
+Adds one or more coderefs to the object.  This allows code to call the named
+methods on the object.  For example, this code:
 
     my $mock = Test::MockObject->new();
     $mock->mock( 'fluorinate',

--- a/t/multimock.t
+++ b/t/multimock.t
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+my $package = 'Test::MockObject';
+use Test::More tests => 3;
+use_ok( $package );
+
+my $mock = Test::MockObject->new();
+
+$mock->mock(
+    foo => sub { 'foo' },
+    bar => sub { 'bar' },
+);
+
+is( $mock->foo(), 'foo', 'mock one in multi-mock' );
+is( $mock->bar(), 'bar', 'mock two in multi-mock' );


### PR DESCRIPTION
I enjoy using this module but find it a bit cumbersome that each mock requires its own
call to `mock()`.

What do you think of this change, to allow creation of multiple mocks via a single `mock()` call?

Thank you for this module!